### PR TITLE
Revert "kein clientseitiges resizing für svg"

### DIFF
--- a/inc/vars.php
+++ b/inc/vars.php
@@ -11,7 +11,6 @@ var uploader_options = {
     },
     context: "'.$this->getProperty('context').'",
     endpoint: "'.$this->getProperty('endpoint').'",
-    loadImageFileTypes: /^image\/(gif|jpeg|png)$/,
     loadImageMaxFileSize: '.((int)$this->getConfig('image-max-filesize')*1000000).',
     imageMaxWidth: '.(int)$this->getConfig('image-max-width').',
     imageMaxHeight: '.(int)$this->getConfig('image-max-height').',


### PR DESCRIPTION
scheint nicht hieran zu liegen, sondern ein safari spezifisches problem zu sein