### PR TITLE
MIME Type Erkennung über Core

### DIFF
--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -116,7 +116,7 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                 rename(rex_path::media($old_name), rex_path::media($new_name));
                 $catid = rex_post('rex_file_category');
                 $title = rex_post('ftitle', 'string', '');
-                $success = rex_mediapool_syncFile($file->name, $catid, $title, $file->size, $file->type);
+                $success = rex_mediapool_syncFile($file->name, $catid, $title);
 
                 // metainfos schreiben
                 uploader_meta::save($success);


### PR DESCRIPTION
Dateigröße & Typ von rex_mediapool_syncFile() setzen lassen. docx Dateien zb wurden als octet/stream erkannt.