### PR TITLE
package.yml: Doppelter Key "perm"

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -2,8 +2,7 @@ package: uploader
 version: '2.0.2'
 author: 'Friends Of REDAXO'
 supportpage: 'https://github.com/FriendsOfREDAXO/uploader'
-perm: uploader[]
-perm: uploader[page]
+
 page:
     title: 'Uploader'
     icon: rex-icon rex-icon-import


### PR DESCRIPTION
Keys können nicht doppelt genutzt werden.

Auf der Ebene nutzt REDAXO übrigens gar nicht den Key "perm", sondern wenn nur innerhalb von `page:`.

Daher habe ich diese zwei Zeilen entfern.