### PR TITLE
fetchRequestValues: empty fields should be ignored

### DIFF
--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -2,7 +2,12 @@
 
 class uploader_iw_upload_handler extends uploader_upload_handler
 {
-   
+    /**
+     * Postvars cache
+     * @var array
+     */
+    private $savedPostVars;
+
     public function generate_response($content, $print_response = true)
     {
         $this->response = $content;
@@ -168,6 +173,10 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                 $mediaMetaResult = $mediaMetaSql->getArray('SELECT column_name AS column_name FROM information_schema.columns WHERE table_name = "rex_media" AND column_name LIKE "med_%"');
                 $metainfos = [];
 
+                if(!isset($this->savedPostVars)) {
+                    $this->savedPostVars = $_POST;
+                }
+
                 if ($mediaMetaSql->getRows() > 0) {
                     foreach ($mediaMetaResult as $metaField) {
                         if (!isset($metaField['column_name'])) {
@@ -175,8 +184,14 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                         }
 
                         $metaName = $metaField['column_name'];
-                        $metainfos[$metaName] = $mediaFile->getValue($metaName);
-                        $_POST[$metaName] = $mediaFile->getValue($metaName);
+                        $value = $mediaFile->getValue($metaName); //Bereits erfasster Wert durch MEDIA_ADDED/MEDIA_UPDATED
+                        if(isset($this->savedPostVars[$metaName]) && mb_strlen($this->savedPostVars[$metaName]) > 0) {
+                            //Uploader-Feature: Nutze angegebene Daten für alle Dateien
+                            $value = $this->savedPostVars[$metaName];
+                        }
+
+                        $metainfos[$metaName] = $value;
+                        $_POST[$metaName] = $value;
                     }
                 }
 

--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -165,16 +165,16 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                 //vorläufiger Bugfix wegen überschriebener Daten aus MEDIA_ADDED / MEDIA_UPDATED
                 //gilt solange, wie der PR 5852 nicht gmerged wurde (https://github.com/redaxo/redaxo/pull/5852)
                 $mediaMetaSql = rex_sql::factory();
-                $mediaMetaResult = $mediaMetaSql->getArray('SELECT column_name FROM information_schema.columns WHERE table_name = "rex_media" AND column_name LIKE "med_%"');
+                $mediaMetaResult = $mediaMetaSql->getArray('SELECT column_name AS column_name FROM information_schema.columns WHERE table_name = "rex_media" AND column_name LIKE "med_%"');
                 $metainfos = [];
 
                 if ($mediaMetaSql->getRows() > 0) {
                     foreach ($mediaMetaResult as $metaField) {
-                        if (!isset($metaField['COLUMN_NAME'])) {
+                        if (!isset($metaField['column_name'])) {
                             continue;
                         }
 
-                        $metaName = $metaField['COLUMN_NAME'];
+                        $metaName = $metaField['column_name'];
                         $metainfos[$metaName] = $mediaFile->getValue($metaName);
                         $_POST[$metaName] = $mediaFile->getValue($metaName);
                     }

--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -162,6 +162,8 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                 $success = rex_mediapool_syncFile($file->name, $catid, $title);
                 $mediaFile = rex_media::get($success['filename']);
 
+                //vorläufiger Bugfix wegen überschriebener Daten aus MEDIA_ADDED / MEDIA_UPDATED
+                //gilt solange, wie der PR 5852 nicht gmerged wurde (https://github.com/redaxo/redaxo/pull/5852)
                 $mediaMetaSql = rex_sql::factory();
                 $mediaMetaResult = $mediaMetaSql->getArray('SELECT column_name FROM information_schema.columns WHERE table_name = "rex_media" AND column_name LIKE "med_%"');
                 $metainfos = [];
@@ -180,7 +182,8 @@ class uploader_iw_upload_handler extends uploader_upload_handler
 
                 // merge metainfos with success array
                 $success = array_merge($success, $metainfos);
-
+                //ENDE vorläufiger Bugfix wegen überschriebener Daten aus MEDIA_ADDED / MEDIA_UPDATED
+                
                 // metainfos schreiben
                 uploader_meta::save($success);
                 

--- a/lib/uploader_metainfo_handler.php
+++ b/lib/uploader_metainfo_handler.php
@@ -44,7 +44,7 @@ class uploader_metainfo_handler extends rex_metainfo_handler
         $media->setTable(rex::getTablePrefix() . 'media');
         $media->setWhere('id=:mediaid', ['mediaid' => $params['id']]);
 
-        parent::fetchRequestValues($params, $media, $sqlFields);
+        parent::fetchRequestValues($params, $media, $sqlFields, false);
 
         // do the save only when metafields are defined
         if ($media->hasValues())

--- a/lib/uploader_metainfo_handler.php
+++ b/lib/uploader_metainfo_handler.php
@@ -44,7 +44,11 @@ class uploader_metainfo_handler extends rex_metainfo_handler
         $media->setTable(rex::getTablePrefix() . 'media');
         $media->setWhere('id=:mediaid', ['mediaid' => $params['id']]);
 
-        parent::fetchRequestValues($params, $media, $sqlFields, false);
+        //Bugfix: daten werden in Kombination mit gespeicherten Daten in MEDIA_ADDED und MEDIA_UPDATED verloren,
+        //weil die aktuellen POST-Vars hineingeschrieben werden, auch wenn sie leer sind.
+        //Benötigt einen Fix in metainfo, weil es den letzten Parameter nicht gibt (https://github.com/redaxo/redaxo/pull/5852)
+//        parent::fetchRequestValues($params, $media, $sqlFields, false);
+        parent::fetchRequestValues($params, $media, $sqlFields);
 
         // do the save only when metafields are defined
         if ($media->hasValues())


### PR DESCRIPTION
Ich hätte da eine Lösung für die Überschriebenen Werte aus den folgenden Issues:
https://github.com/FriendsOfREDAXO/mediapool_exif/issues/18
https://github.com/FriendsOfREDAXO/uploader/issues/60
https://github.com/FriendsOfREDAXO/mediapool_exif/issues/28

Dafür müsste eine Anpassung an `metainfo` gemacht werden, der leere Felder beim Aufruf von `fetchRequestValues` ignorieren kann.

PR: https://github.com/redaxo/redaxo/pull/5852