### PR TITLE
Fix server-side category validation, allow default 0, and replace jfu…

### DIFF
--- a/assets/uploader.js
+++ b/assets/uploader.js
@@ -149,7 +149,12 @@ jQuery(function () {
     });
 
     $form.bind('fileuploadcompleted', function (e, data) {
-        if (data.result.files[0].hasOwnProperty('error')) {
+        var file = data.result.files[0];
+        if (file.hasOwnProperty('error') && file.error) {
+            // HTML-Tags entfernen
+            var cleanError = file.error.replace(/<[^>]*>/g, '');
+            // In der UI aktualisieren
+            data.context.find('.error').text(cleanError);
             return true;
         }
     });
@@ -158,6 +163,12 @@ jQuery(function () {
         var $li = $(data.context[0]);
         $li.find('.size').remove();
         $li.find('.preview').addClass('warning').append(get_mime_icon(data.files[0].name));
+        // Fehlernachricht tagfrei anzeigen
+        var err = data.files[0].error;
+        if (err) {
+            var clean = err.replace(/<[^>]*>/g, '');
+            $li.find('.error').text(clean);
+        }
     });
 
     // datei nach upload uebernehmen

--- a/assets/uploader.js
+++ b/assets/uploader.js
@@ -53,7 +53,7 @@ jQuery(function () {
             dataType: 'json',
             disableImagePreview: true,
             loadImageMaxFileSize: uploader_options.loadImageMaxFileSize, // 30 mb
-            maxChunkSize: 1000000, // 5 mb
+            maxChunkSize: 5000000, // 5 mb
             disableImageResize: /Android(?!.*Chrome)|Opera/.test(window.navigator && navigator.userAgent),
             imageMaxWidth: uploader_options.imageMaxWidth,
             imageMaxHeight: uploader_options.imageMaxHeight,

--- a/assets/uploader.js
+++ b/assets/uploader.js
@@ -2,6 +2,9 @@
 
 jQuery(function () {
 
+    // Liste bereits hinzugefügter Dateinamen
+    var uploadedFiles = [];
+
     // https://stackoverflow.com/a/11582513
     function getURLParameter(name) {
         return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search) || [null, ''])[1].replace(/\+/g, '%20')) || null;
@@ -127,6 +130,17 @@ jQuery(function () {
 
     $form.bind('fileuploadadded', function (e, data) {
         $(data.context[0]).find('.preview').append(get_mime_icon(data.files[0].name));
+    });
+
+    $form.on('fileuploadadd', function (e, data) {
+        var name = data.files[0].name;
+        if (uploadedFiles.indexOf(name) !== -1) {
+            // Duplikat entfernen und Hinweis anzeigen
+            data.context.remove();
+            alert('Datei "' + name + '" wurde bereits hinzugefügt und wird übersprungen.');
+            return false;
+        }
+        uploadedFiles.push(name);
     });
 
     $('#resize-images').on('click', function () {

--- a/assets/uploader.js
+++ b/assets/uploader.js
@@ -50,7 +50,7 @@ jQuery(function () {
             dataType: 'json',
             disableImagePreview: true,
             loadImageMaxFileSize: uploader_options.loadImageMaxFileSize, // 30 mb
-            maxChunkSize: 5000000, // 5 mb
+            maxChunkSize: 1000000, // 5 mb
             disableImageResize: /Android(?!.*Chrome)|Opera/.test(window.navigator && navigator.userAgent),
             imageMaxWidth: uploader_options.imageMaxWidth,
             imageMaxHeight: uploader_options.imageMaxHeight,

--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -15,6 +15,10 @@ class uploader_iw_upload_handler extends uploader_upload_handler
             // iw patch redaxo thumbnails laden
             
             foreach ($content['files'] as $v) {
+                // HTML-Tags aus Fehlermeldungen entfernen
+                if (isset($v->error)) {
+                    $v->error = strip_tags($v->error);
+                }
                 if (isset($v->upload_complete)) {
                     $media = rex_media::get($v->name);
                     if ($media && $media->isImage()) {

--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -61,16 +61,18 @@ class uploader_iw_upload_handler extends uploader_upload_handler
     
     protected function upcount_name_callback($matches)
     {
+        // Erhöhe vorhandenen Zähler oder setze auf 1
         $index = isset($matches[1]) ? ((int)$matches[1]) + 1 : 1;
         $ext   = isset($matches[2]) ? $matches[2] : '';
-        
-        return ' (jfucounter' . $index . 'jfucounter)' . $ext;
+        // Neuer Zähler im Format _Zähler vor der Erweiterung
+        return '_'. $index . $ext;
     }
     
     protected function upcount_name($name)
     {
+        // Suche nach optionalem _Zähler vor der Dateiendung und erhöhe diesen
         return preg_replace_callback(
-            '/(?:(?: \(jfucounter([\d]+)jfucounter\))?(\.[^.]+))?$/',
+            '/(?:_([\d]+))?(\.[^.]+)$/',
             array($this, 'upcount_name_callback'),
             $name,
             1

--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -141,12 +141,13 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                 
                 // Für Medienpool vorbereiten
                 $catid = rex_post('rex_file_category', 'int', 0);
-                // Server-seitige Kontrolle der Kategorie-ID: 0 (Standard) ist erlaubt
-                if ($catid > 0) {
-                    $category = rex_media_category::get($catid);
-                    if (!$category || !rex::getUser()->getComplexPerm('media')->hasCategoryPerm($catid)) {
-                        throw new rex_api_exception('Ungültige Kategorie-ID');
-                    }
+                // Server-seitige Kontrolle der Kategorie-ID: Existenz prüfen für >0
+                if ($catid > 0 && !rex_media_category::get($catid)) {
+                    throw new rex_api_exception('Ungültige Kategorie-ID');
+                }
+                // Berechtigung prüfen für alle Kategorien, auch ID 0
+                if (!rex::getUser()->getComplexPerm('media')->hasCategoryPerm($catid)) {
+                    throw new rex_api_exception('Ungültige Kategorie-ID');
                 }
                 $title = rex_post('ftitle', 'string', '');
                 

--- a/lib/uploader_iw_upload_handler.php
+++ b/lib/uploader_iw_upload_handler.php
@@ -138,6 +138,12 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                 // iw patch start
                 $file->upload_complete = 1;
                 $orig_filename = basename($file_path);
+                // jfucounter-Platzhalter früh ersetzen
+                $orig_filename = preg_replace_callback(
+                    '/\s*\(jfucounter(\d+)jfucounter\)/',
+                    function($m){ return '_'.$m[1]; },
+                    $orig_filename
+                );
                 
                 // Für Medienpool vorbereiten
                 $catid = rex_post('rex_file_category', 'int', 0);
@@ -155,13 +161,6 @@ class uploader_iw_upload_handler extends uploader_upload_handler
                 if (rex_post("filename-as-title", "int", "") === 1) {
                     $title = pathinfo($orig_filename, PATHINFO_FILENAME);
                 }
-                
-                // jfucounter-Platzhalter im Dateinamen ersetzen
-                $orig_filename = preg_replace_callback(
-                    '/\s*\(jfucounter(\d+)jfucounter\)/',
-                    function($m){ return '_'.$m[1]; },
-                    $orig_filename
-                );
                 
                 try {
                     // Vorbereiten der Datei für den Medienpool


### PR DESCRIPTION
Serverseitige Prüfung der Zielkategorie-ID: 
wird nun sichergestellt, dass die Kategorie existiert und der Benutzer die Rechte besitzt.
fixed: https://github.com/FriendsOfREDAXO/uploader/issues/90

Platzhalter (jfucounterNjfucounter) werden vor dem Speichern in _N umgewandelt.
fixed: https://github.com/FriendsOfREDAXO/uploader/issues/91

Zusätzliche Absicherung in generate_response(), sodass rex_media::get() nur auf isImage() geprüft wird, wenn tatsächlich ein Objekt zurückkommt.